### PR TITLE
Set removeImages=false

### DIFF
--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
@@ -23,7 +23,7 @@ class ComposeExtension {
 
     boolean stopContainers = true
     boolean removeContainers = true
-    boolean removeImages = true
+    boolean removeImages = false
     boolean removeVolumes = true
 
     ComposeExtension(Project project, ComposeUp upTask, ComposeDown downTask) {


### PR DESCRIPTION
I do no think it is wise to remove images on docker-compose down by default.
It causes the images to be redownloaded each time which is time-consuming.