### PR TITLE
Allow using localhost if useNetworkGateway=false

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ dockerCompose {
     // removeContainers = false
     // removeImages = true
     // removeVolumes = false
+    // useNetworkGateway = false  // Connect to localhost instead of gateway. Useful for Docker for Mac.
 }
 
 test.doFirst {

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
@@ -25,6 +25,7 @@ class ComposeExtension {
     boolean removeContainers = true
     boolean removeImages = false
     boolean removeVolumes = true
+    boolean useNetworkGateway = true
 
     ComposeExtension(Project project, ComposeUp upTask, ComposeDown downTask) {
         this.project = project

--- a/src/main/groovy/com/avast/gradle/dockercompose/ServiceHost.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ServiceHost.groovy
@@ -10,5 +10,6 @@ class ServiceHost {
 
 enum ServiceHostType {
     NetworkGateway,
-    RemoteDockerHost
+    RemoteDockerHost,
+    LocalHost
 }

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
@@ -101,7 +101,7 @@ class ComposeUp extends DefaultTask {
         if (dockerHost) {
             logger.debug("'DOCKER_HOST environment variable detected - will be used as hostname of service $serviceName'")
             new ServiceHost(host: dockerHost.toURI().host, type: ServiceHostType.RemoteDockerHost)
-        } else {
+        } else if (extension.useNetworkGateway) {
             // read gateway of first containers network
             String gateway
             Map<String, Object> networkSettings = inspection.NetworkSettings
@@ -115,6 +115,9 @@ class ComposeUp extends DefaultTask {
                 logger.debug("Will use $gateway as host of $serviceName")
             }
             new ServiceHost(host: gateway, type: ServiceHostType.NetworkGateway)
+        } else {
+            logger.debug("Will use localhost as host of $serviceName")
+            new ServiceHost(host: 'localhost', type: ServiceHostType.LocalHost)
         }
     }
 
@@ -131,6 +134,7 @@ class ComposeUp extends DefaultTask {
             }
             else {
                 switch (host.type) {
+                    case ServiceHostType.LocalHost:
                     case ServiceHostType.NetworkGateway:
                     case ServiceHostType.RemoteDockerHost:
                         if (forwardedPortsInfos.size() > 1) {


### PR DESCRIPTION
This commit adds a boolean flag "useNetworkGateway" that, when set to true (default), will use the current method of accessing the service ports through the gateway, but when set to false will use localhost instead.

This allows the usage of the plugin on the new Docker for Mac beta, where exposed ports are accessible on localhost only.

*Question*: Why is not connecting to localhost default? In what workflow is connecting to the gateway better (curious)?