### PR TITLE
Add logic for Docker for Mac and removed useNetworkGateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ dockerCompose {
     // removeContainers = false
     // removeImages = true
     // removeVolumes = false
-    // useNetworkGateway = false  // Connect to localhost instead of gateway. Useful for Docker for Mac.
 }
 
 test.doFirst {

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
@@ -25,7 +25,6 @@ class ComposeExtension {
     boolean removeContainers = true
     boolean removeImages = false
     boolean removeVolumes = true
-    boolean useNetworkGateway = true
 
     ComposeExtension(Project project, ComposeUp upTask, ComposeDown downTask) {
         this.project = project

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
@@ -101,7 +101,12 @@ class ComposeUp extends DefaultTask {
         if (dockerHost) {
             logger.debug("'DOCKER_HOST environment variable detected - will be used as hostname of service $serviceName'")
             new ServiceHost(host: dockerHost.toURI().host, type: ServiceHostType.RemoteDockerHost)
-        } else if (extension.useNetworkGateway) {
+        } else if (isMac()) {
+            // If running on Mac OS and DOCKER_HOST is not set, we can assume that
+            // we are using Docker for Mac, in which case we should connect to localhost
+            logger.debug("Will use localhost as host of $serviceName")
+            new ServiceHost(host: 'localhost', type: ServiceHostType.LocalHost)
+        } else {
             // read gateway of first containers network
             String gateway
             Map<String, Object> networkSettings = inspection.NetworkSettings
@@ -115,9 +120,6 @@ class ComposeUp extends DefaultTask {
                 logger.debug("Will use $gateway as host of $serviceName")
             }
             new ServiceHost(host: gateway, type: ServiceHostType.NetworkGateway)
-        } else {
-            logger.debug("Will use localhost as host of $serviceName")
-            new ServiceHost(host: 'localhost', type: ServiceHostType.LocalHost)
         }
     }
 
@@ -187,5 +189,9 @@ class ComposeUp extends DefaultTask {
             }
             os.toString().trim()
         }
+    }
+
+    private static boolean isMac() {
+        System.getProperty("os.name").startsWith("Mac")
     }
 }

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
@@ -192,6 +192,6 @@ class ComposeUp extends DefaultTask {
     }
 
     private static boolean isMac() {
-        System.getProperty("os.name").startsWith("Mac")
+        System.getProperty("os.name").toLowerCase().startsWith("mac")
     }
 }


### PR DESCRIPTION
Instead of having to set "useNetworkGateway" when using Docker for Mac, the plugin will now automatically use localhost when on a Mac and DOCKER_HOST is not set.

This fixes #19