### PR TITLE
Fixes #26: Ability to pass env to docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ dockerCompose {
     // removeContainers = false
     // removeImages = "None" // Other accepted values are: "All" and "Local"
     // removeVolumes = false
+    // environment.put 'BACKEND_ADDRESS', '192.168.1.100' // Pass environment variable to 'docker-compose' for substitution in compose file
 }
 
 test.doFirst {

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
@@ -26,6 +26,8 @@ class ComposeExtension {
     RemoveImages removeImages = RemoveImages.None
     boolean removeVolumes = true
 
+    Map<String, Object> environment = new HashMap<String, Object>(System.getenv());
+
     ComposeExtension(Project project, ComposeUp upTask, ComposeDown downTask) {
         this.project = project
         this.downTask = downTask

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
@@ -31,10 +31,12 @@ class ComposeUp extends DefaultTask {
     void up() {
         if (extension.buildBeforeUp) {
             project.exec { ExecSpec e ->
+                e.environment = extension.environment
                 e.commandLine extension.composeCommand('build')
             }
         }
         project.exec { ExecSpec e ->
+            e.environment = extension.environment
             e.commandLine extension.composeCommand('up', '-d')
         }
         try {

--- a/src/test/groovy/com/avast/gradle/dockercompose/DockerComposePluginTest.groovy
+++ b/src/test/groovy/com/avast/gradle/dockercompose/DockerComposePluginTest.groovy
@@ -244,4 +244,37 @@ class DockerComposePluginTest extends Specification {
             projectDir.deleteOnExit()
         }
     }
+
+    def "docker-compose substitutes environment variables"() {
+        def projectDir = new TmpDirTemporaryFileProvider().createTemporaryDirectory("gradle", "projectDir")
+        new File(projectDir, 'docker-compose.yml') << '''
+            web:
+                image: nginx
+                ports:
+                  - $MY_WEB_PORT
+        '''
+        def project = ProjectBuilder.builder().withProjectDir(projectDir).build()
+        project.plugins.apply 'docker-compose'
+        def extension = (ComposeExtension) project.extensions.findByName('dockerCompose')
+        project.tasks.create('integrationTest').doLast {
+            ServiceInfo webInfo = project.dockerCompose.servicesInfos.web
+            assert webInfo.ports.containsKey(80)
+        }
+        when:
+        extension.useComposeFiles = ['docker-compose.yml']
+        extension.environment.put 'MY_WEB_PORT', 80
+        extension.waitForTcpPorts = false  // checked in assert
+        project.tasks.composeUp.up()
+        project.tasks.integrationTest.execute()
+        then:
+        noExceptionThrown()
+        cleanup:
+        project.tasks.composeDown.down()
+        try {
+            projectDir.delete()
+        } catch(ignored) {
+            projectDir.deleteOnExit()
+        }
+    }
+
 }


### PR DESCRIPTION
* dockerCompose closure now accepts environment
  property that is passed to project.exec in ComposeUp task