### PR TITLE
Fixes #26: Pass environment to all docker-compose invocations

### DIFF
--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDown.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDown.groovy
@@ -19,6 +19,7 @@ class ComposeDown extends DefaultTask {
     void down() {
         if (extension.stopContainers) {
             project.exec { ExecSpec e ->
+                e.environment = extension.environment
                 e.commandLine extension.composeCommand('stop')
             }
             if (extension.removeContainers) {
@@ -36,10 +37,12 @@ class ComposeDown extends DefaultTask {
                         args += ['--volumes']
                     }
                     project.exec { ExecSpec e ->
+                        e.environment = extension.environment
                         e.commandLine extension.composeCommand(args)
                     }
                 } else {
                     project.exec { ExecSpec e ->
+                        e.environment = extension.environment
                         e.commandLine extension.composeCommand('rm', '-f')
                     }
                 }
@@ -50,6 +53,7 @@ class ComposeDown extends DefaultTask {
     VersionNumber getDockerComposeVersion() {
         new ByteArrayOutputStream().withStream { os ->
             project.exec { ExecSpec e ->
+                e.environment = extension.environment
                 e.commandLine extension.composeCommand('--version')
                 e.standardOutput = os
             }

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
@@ -79,6 +79,7 @@ class ComposeUp extends DefaultTask {
     String getContainerId(String serviceName) {
         new ByteArrayOutputStream().withStream { os ->
             project.exec { ExecSpec e ->
+                e.environment = extension.environment
                 e.commandLine extension.composeCommand('ps', '-q', serviceName)
                 e.standardOutput = os
             }


### PR DESCRIPTION
* Otherwise docker-compose generates confusing message
  The variable is not set. Defaulting to a blank string
  on ps, stop, down commands.