### PR TITLE
Add ComposePull task

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Simplifies usage of [Docker Compose](https://www.docker.com/docker-compose) for 
 
 `composeDown` task stops the application and removes the containers.
 
+`composePull` task pulls and optionally builds the images required by the application. This is useful, for example, with a CI platform that caches docker images to decrease build times.
+
 ## Why to use Docker Compose?
 1. I want to be able to run my application on my computer, and it must work for my colleagues as well. Just execute `docker-compose up` and I'm done.
 2. I want to be able to test my application on my computer - I don't wanna wait till my application is deployed into dev/testing environment and acceptance/end2end tests get executed. I want to execute these tests on my computer - it means execute `docker-compose up` before these tests.

--- a/src/main/groovy/com/avast/gradle/dockercompose/DockerComposePlugin.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/DockerComposePlugin.groovy
@@ -1,6 +1,7 @@
 package com.avast.gradle.dockercompose
 
 import com.avast.gradle.dockercompose.tasks.ComposeDown
+import com.avast.gradle.dockercompose.tasks.ComposePull
 import com.avast.gradle.dockercompose.tasks.ComposeUp
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -9,10 +10,12 @@ class DockerComposePlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
         ComposeUp upTask = project.tasks.create('composeUp', ComposeUp)
+        ComposePull pullTask = project.tasks.create('composePull', ComposePull)
         ComposeDown downTask = project.tasks.create('composeDown', ComposeDown)
         ComposeExtension extension = project.extensions.create('dockerCompose', ComposeExtension, project, upTask, downTask)
         upTask.extension = extension
         upTask.downTask = downTask
         downTask.extension = extension
+		pullTask.extension = extension
     }
 }

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposePull.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposePull.groovy
@@ -1,0 +1,30 @@
+package com.avast.gradle.dockercompose.tasks
+
+import com.avast.gradle.dockercompose.ComposeExtension
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecSpec
+
+class ComposePull extends DefaultTask {
+
+    ComposeExtension extension
+
+    ComposePull() {
+        group = 'docker'
+        description = 'Pulls and builds all images of docker-compose project'
+    }
+
+    @TaskAction
+    void pull() {
+        if (extension.buildBeforeUp) {
+            project.exec { ExecSpec e ->
+                e.environment = extension.environment
+                e.commandLine extension.composeCommand('build')
+            }
+        }
+        project.exec { ExecSpec e ->
+            e.environment = extension.environment
+            e.commandLine extension.composeCommand('pull')
+        }
+    }
+}


### PR DESCRIPTION
The docker-compose pull command can be used to pull images without starting containers to cache containers.