### PR TITLE
Add Vagrantfile for consistent test runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ crashlytics-build.properties
 
 # NetBeans
 /.nb-gradle/
+
+# Vagrant
+.vagrant/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,6 +10,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "2048"
+    vb.cpus = 2
   end
 
   config.vm.provider "vmware_fusion" do |v|
@@ -20,14 +21,16 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", inline: <<-SHELL
     export DEBIAN_FRONTEND=noninteractive
     apt-get -y update
-    apt-get -y install apt-transport-https ca-certificates software-properties-common
-    apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
-    echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" >> /etc/apt/sources.list.d/docker.list
+    apt-get -y install apt-transport-https ca-certificates curl software-properties-common
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
     add-apt-repository ppa:openjdk-r/ppa
     apt-get -y update
-    apt-get -y install docker-engine linux-image-extra-$(uname -r) linux-image-extra-virtual openjdk-8-jdk-headless
+    apt-get -y install docker-ce linux-image-extra-$(uname -r) linux-image-extra-virtual openjdk-8-jdk-headless
     usermod -aG docker vagrant
     # Workaround https://bugs.launchpad.net/ubuntu/+source/ca-certificates-java/+bug/1396760
     /var/lib/dpkg/info/ca-certificates-java.postinst configure
+    curl -sL https://github.com/docker/compose/releases/download/1.12.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
+    chmod +x /usr/local/bin/docker-compose
   SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,35 +2,23 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "boxcutter/ubuntu1404"
+  config.vm.box = "boxcutter/ubuntu1604"
 
   if Vagrant.has_plugin?("vagrant-cachier")
     config.cache.scope = :box
   end
 
   config.vm.provider "virtualbox" do |vb|
-    vb.memory = "2048"
+    vb.memory = "1024"
     vb.cpus = 2
   end
 
   config.vm.provider "vmware_fusion" do |v|
-    v.vmx["memsize"] = "2048"
+    v.vmx["memsize"] = "1024"
     v.vmx["numvcpus"] = "2"
   end
 
-  config.vm.provision "shell", inline: <<-SHELL
-    export DEBIAN_FRONTEND=noninteractive
-    apt-get -y update
-    apt-get -y install apt-transport-https ca-certificates curl software-properties-common
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-    add-apt-repository ppa:openjdk-r/ppa
-    apt-get -y update
-    apt-get -y install docker-ce linux-image-extra-$(uname -r) linux-image-extra-virtual openjdk-8-jdk-headless
-    usermod -aG docker vagrant
-    # Workaround https://bugs.launchpad.net/ubuntu/+source/ca-certificates-java/+bug/1396760
-    /var/lib/dpkg/info/ca-certificates-java.postinst configure
-    curl -sL https://github.com/docker/compose/releases/download/1.12.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
-    chmod +x /usr/local/bin/docker-compose
-  SHELL
+  config.vm.provision "docker" do |d|
+    d.build_image "/vagrant", args: '-t build-image'
+  end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,5 +27,7 @@ Vagrant.configure("2") do |config|
     apt-get -y update
     apt-get -y install docker-engine linux-image-extra-$(uname -r) linux-image-extra-virtual openjdk-8-jdk-headless
     usermod -aG docker vagrant
+    # Workaround https://bugs.launchpad.net/ubuntu/+source/ca-certificates-java/+bug/1396760
+    /var/lib/dpkg/info/ca-certificates-java.postinst configure
   SHELL
 end


### PR DESCRIPTION
Not all tests run on my Mac due to use of docker-machine. Some of those can be non-trivial to fix. I created this Vagrant box to make a minimal and consistent environment for running the tests.