### PR TITLE
Support supplying an optional param to specify docker working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ dockerCompose {
     // projectName = 'my-project' // allow to set custom docker-compose project name (defaults to directory name)
     // executable = '/path/to/docker-compose' // allow to set the path of the docker-compose executable (usefull if not present in PATH)
     // dockerExecutable = '/path/to/docker' // allow to set the path of the docker executable (usefull if not present in PATH)
+    // dockerWorkingDirectory = '/path/to/where/docker/should/be/invoked/from'
     // environment.put 'BACKEND_ADDRESS', '192.168.1.100' // Pass environment variable to 'docker-compose' for substitution in compose file
 }
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ dockerCompose {
     // projectName = 'my-project' // allow to set custom docker-compose project name (defaults to directory name)
     // executable = '/path/to/docker-compose' // allow to set the path of the docker-compose executable (usefull if not present in PATH)
     // dockerExecutable = '/path/to/docker' // allow to set the path of the docker executable (usefull if not present in PATH)
-    // dockerWorkingDirectory = '/path/to/where/docker/should/be/invoked/from'
+    // dockerComposeWorkingDirectory = '/path/where/docker-compose/is/invoked/from'
     // environment.put 'BACKEND_ADDRESS', '192.168.1.100' // Pass environment variable to 'docker-compose' for substitution in compose file
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jan 12 11:56:04 CET 2017
+#Fri Apr 28 10:59:50 CDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Apr 28 10:59:50 CDT 2017
+#Thu Jan 12 11:56:04 CET 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-bin.zip

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
@@ -38,6 +38,8 @@ class ComposeExtension {
 
     String dockerExecutable = 'docker'
 
+    String dockerWorkingDirectory = null;
+
     ComposeExtension(Project project, ComposeUp upTask, ComposeDown downTask) {
         this.project = project
         this.downTask = downTask
@@ -103,6 +105,9 @@ class ComposeExtension {
         def env = this.environment
         new ByteArrayOutputStream().withStream { os ->
             p.exec { ExecSpec e ->
+                if (dockerWorkingDirectory != null) {
+                    e.setWorkingDir(dockerWorkingDirectory)
+                }
                 e.environment = env
                 e.commandLine composeCommand('--version')
                 e.standardOutput = os

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
@@ -79,6 +79,12 @@ class ComposeExtension {
         }
     }
 
+    void setExecSpecWorkingDirectory(ExecSpec e) {
+        if(dockerWorkingDirectory != null) {
+            e.setWorkingDir(dockerWorkingDirectory)
+        }
+    }
+
     /**
      * Composes docker-compose command, mainly adds '-f' and '-p' options.
      */
@@ -105,9 +111,7 @@ class ComposeExtension {
         def env = this.environment
         new ByteArrayOutputStream().withStream { os ->
             p.exec { ExecSpec e ->
-                if (dockerWorkingDirectory != null) {
-                    e.setWorkingDir(dockerWorkingDirectory)
-                }
+                setExecSpecWorkingDirectory(e)
                 e.environment = env
                 e.commandLine composeCommand('--version')
                 e.standardOutput = os

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
@@ -38,7 +38,7 @@ class ComposeExtension {
 
     String dockerExecutable = 'docker'
 
-    String dockerWorkingDirectory = null;
+    String dockerComposeWorkingDirectory = null;
 
     ComposeExtension(Project project, ComposeUp upTask, ComposeDown downTask) {
         this.project = project
@@ -80,8 +80,8 @@ class ComposeExtension {
     }
 
     void setExecSpecWorkingDirectory(ExecSpec e) {
-        if(dockerWorkingDirectory != null) {
-            e.setWorkingDir(dockerWorkingDirectory)
+        if(dockerComposeWorkingDirectory != null) {
+            e.setWorkingDir(dockerComposeWorkingDirectory)
         }
     }
 

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDown.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDown.groovy
@@ -19,9 +19,7 @@ class ComposeDown extends DefaultTask {
     void down() {
         if (extension.stopContainers) {
             project.exec { ExecSpec e ->
-                if (extension.dockerWorkingDirectory != null) {
-                    e.setWorkingDir(extension.dockerWorkingDirectory)
-                }
+                extension.setExecSpecWorkingDirectory(e)
                 e.environment = extension.environment
                 e.commandLine extension.composeCommand('stop')
             }
@@ -40,17 +38,13 @@ class ComposeDown extends DefaultTask {
                         args += ['--volumes']
                     }
                     project.exec { ExecSpec e ->
-                        if (extension.dockerWorkingDirectory != null) {
-                            e.setWorkingDir(extension.dockerWorkingDirectory)
-                        }
+                        extension.setExecSpecWorkingDirectory(e)
                         e.environment = extension.environment
                         e.commandLine extension.composeCommand(args)
                     }
                 } else {
                     project.exec { ExecSpec e ->
-                        if (extension.dockerWorkingDirectory != null) {
-                            e.setWorkingDir(extension.dockerWorkingDirectory)
-                        }
+                        extension.setExecSpecWorkingDirectory(e)
                         e.environment = extension.environment
                         e.commandLine extension.composeCommand('rm', '-f')
                     }

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDown.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDown.groovy
@@ -19,6 +19,9 @@ class ComposeDown extends DefaultTask {
     void down() {
         if (extension.stopContainers) {
             project.exec { ExecSpec e ->
+                if (extension.dockerWorkingDirectory != null) {
+                    e.setWorkingDir(extension.dockerWorkingDirectory)
+                }
                 e.environment = extension.environment
                 e.commandLine extension.composeCommand('stop')
             }
@@ -37,11 +40,17 @@ class ComposeDown extends DefaultTask {
                         args += ['--volumes']
                     }
                     project.exec { ExecSpec e ->
+                        if (extension.dockerWorkingDirectory != null) {
+                            e.setWorkingDir(extension.dockerWorkingDirectory)
+                        }
                         e.environment = extension.environment
                         e.commandLine extension.composeCommand(args)
                     }
                 } else {
                     project.exec { ExecSpec e ->
+                        if (extension.dockerWorkingDirectory != null) {
+                            e.setWorkingDir(extension.dockerWorkingDirectory)
+                        }
                         e.environment = extension.environment
                         e.commandLine extension.composeCommand('rm', '-f')
                     }

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposePull.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposePull.groovy
@@ -18,17 +18,13 @@ class ComposePull extends DefaultTask {
     void pull() {
         if (extension.buildBeforeUp) {
             project.exec { ExecSpec e ->
-                if (extension.dockerWorkingDirectory != null) {
-                    e.setWorkingDir(extension.dockerWorkingDirectory)
-                }
+                extension.setExecSpecWorkingDirectory(e)
                 e.environment = extension.environment
                 e.commandLine extension.composeCommand('build')
             }
         }
         project.exec { ExecSpec e ->
-            if (extension.dockerWorkingDirectory != null) {
-                e.setWorkingDir(extension.dockerWorkingDirectory)
-            }
+            extension.setExecSpecWorkingDirectory(e)
             e.environment = extension.environment
             e.commandLine extension.composeCommand('pull')
         }

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposePull.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposePull.groovy
@@ -18,11 +18,17 @@ class ComposePull extends DefaultTask {
     void pull() {
         if (extension.buildBeforeUp) {
             project.exec { ExecSpec e ->
+                if (extension.dockerWorkingDirectory != null) {
+                    e.setWorkingDir(extension.dockerWorkingDirectory)
+                }
                 e.environment = extension.environment
                 e.commandLine extension.composeCommand('build')
             }
         }
         project.exec { ExecSpec e ->
+            if (extension.dockerWorkingDirectory != null) {
+                e.setWorkingDir(extension.dockerWorkingDirectory)
+            }
             e.environment = extension.environment
             e.commandLine extension.composeCommand('pull')
         }

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
@@ -33,17 +33,13 @@ class ComposeUp extends DefaultTask {
     void up() {
         if (extension.buildBeforeUp) {
             project.exec { ExecSpec e ->
-                if (extension.dockerWorkingDirectory != null) {
-                    e.setWorkingDir(extension.dockerWorkingDirectory)
-                }
+                extension.setExecSpecWorkingDirectory(e)
                 e.environment = extension.environment
                 e.commandLine extension.composeCommand('build')
             }
         }
         project.exec { ExecSpec e ->
-            if (extension.dockerWorkingDirectory != null) {
-                e.setWorkingDir(extension.dockerWorkingDirectory)
-            }
+            extension.setExecSpecWorkingDirectory(e)
             e.environment = extension.environment
             e.commandLine extension.composeCommand('up', '-d')
         }
@@ -70,9 +66,7 @@ class ComposeUp extends DefaultTask {
             @Override
             void run() {
                 project.exec { ExecSpec e ->
-                    if (extension.dockerWorkingDirectory != null) {
-                        e.setWorkingDir(extension.dockerWorkingDirectory)
-                    }
+                    extension.setExecSpecWorkingDirectory(e)
                     e.environment = extension.environment
                     e.commandLine extension.composeCommand('logs', '-f', '--no-color')
                     e.standardOutput = new OutputStream() {
@@ -117,9 +111,7 @@ class ComposeUp extends DefaultTask {
         if (extension.getDockerComposeVersion() >= VersionNumber.parse('1.6.0')) {
             new ByteArrayOutputStream().withStream { os ->
                 project.exec { ExecSpec e ->
-                    if (extension.dockerWorkingDirectory != null) {
-                        e.setWorkingDir(extension.dockerWorkingDirectory)
-                    }
+                    extension.setExecSpecWorkingDirectory(e)
                     e.environment = extension.environment
                     e.commandLine extension.composeCommand('config', '--services')
                     e.standardOutput = os
@@ -165,9 +157,7 @@ class ComposeUp extends DefaultTask {
     String getContainerId(String serviceName) {
         new ByteArrayOutputStream().withStream { os ->
             project.exec { ExecSpec e ->
-                if (extension.dockerWorkingDirectory != null) {
-                    e.setWorkingDir(extension.dockerWorkingDirectory)
-                }
+                extension.setExecSpecWorkingDirectory(e)
                 e.environment = extension.environment
                 e.commandLine extension.composeCommand('ps', '-q', serviceName)
                 e.standardOutput = os
@@ -179,9 +169,7 @@ class ComposeUp extends DefaultTask {
     Map<String, Object> getDockerInspection(String containerId) {
         new ByteArrayOutputStream().withStream { os ->
             project.exec { ExecSpec e ->
-                if (extension.dockerWorkingDirectory != null) {
-                    e.setWorkingDir(extension.dockerWorkingDirectory)
-                }
+                extension.setExecSpecWorkingDirectory(e)
                 e.environment = extension.environment
                 e.commandLine extension.dockerCommand('inspect', containerId)
                 e.standardOutput os
@@ -322,9 +310,7 @@ class ComposeUp extends DefaultTask {
         def containerId = getContainerId(serviceName)
         new ByteArrayOutputStream().withStream { os ->
             project.exec { ExecSpec e ->
-                if (extension.dockerWorkingDirectory != null) {
-                    e.setWorkingDir(extension.dockerWorkingDirectory)
-                }
+                extension.setExecSpecWorkingDirectory(e)
                 e.environment = extension.environment
                 e.commandLine extension.dockerCommand('logs', '--follow=false', containerId)
                 e.standardOutput = os

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
@@ -33,11 +33,17 @@ class ComposeUp extends DefaultTask {
     void up() {
         if (extension.buildBeforeUp) {
             project.exec { ExecSpec e ->
+                if (extension.dockerWorkingDirectory != null) {
+                    e.setWorkingDir(extension.dockerWorkingDirectory)
+                }
                 e.environment = extension.environment
                 e.commandLine extension.composeCommand('build')
             }
         }
         project.exec { ExecSpec e ->
+            if (extension.dockerWorkingDirectory != null) {
+                e.setWorkingDir(extension.dockerWorkingDirectory)
+            }
             e.environment = extension.environment
             e.commandLine extension.composeCommand('up', '-d')
         }
@@ -64,6 +70,9 @@ class ComposeUp extends DefaultTask {
             @Override
             void run() {
                 project.exec { ExecSpec e ->
+                    if (extension.dockerWorkingDirectory != null) {
+                        e.setWorkingDir(extension.dockerWorkingDirectory)
+                    }
                     e.environment = extension.environment
                     e.commandLine extension.composeCommand('logs', '-f', '--no-color')
                     e.standardOutput = new OutputStream() {
@@ -108,6 +117,9 @@ class ComposeUp extends DefaultTask {
         if (extension.getDockerComposeVersion() >= VersionNumber.parse('1.6.0')) {
             new ByteArrayOutputStream().withStream { os ->
                 project.exec { ExecSpec e ->
+                    if (extension.dockerWorkingDirectory != null) {
+                        e.setWorkingDir(extension.dockerWorkingDirectory)
+                    }
                     e.environment = extension.environment
                     e.commandLine extension.composeCommand('config', '--services')
                     e.standardOutput = os
@@ -153,6 +165,9 @@ class ComposeUp extends DefaultTask {
     String getContainerId(String serviceName) {
         new ByteArrayOutputStream().withStream { os ->
             project.exec { ExecSpec e ->
+                if (extension.dockerWorkingDirectory != null) {
+                    e.setWorkingDir(extension.dockerWorkingDirectory)
+                }
                 e.environment = extension.environment
                 e.commandLine extension.composeCommand('ps', '-q', serviceName)
                 e.standardOutput = os
@@ -164,6 +179,9 @@ class ComposeUp extends DefaultTask {
     Map<String, Object> getDockerInspection(String containerId) {
         new ByteArrayOutputStream().withStream { os ->
             project.exec { ExecSpec e ->
+                if (extension.dockerWorkingDirectory != null) {
+                    e.setWorkingDir(extension.dockerWorkingDirectory)
+                }
                 e.environment = extension.environment
                 e.commandLine extension.dockerCommand('inspect', containerId)
                 e.standardOutput os
@@ -304,6 +322,9 @@ class ComposeUp extends DefaultTask {
         def containerId = getContainerId(serviceName)
         new ByteArrayOutputStream().withStream { os ->
             project.exec { ExecSpec e ->
+                if (extension.dockerWorkingDirectory != null) {
+                    e.setWorkingDir(extension.dockerWorkingDirectory)
+                }
                 e.environment = extension.environment
                 e.commandLine extension.dockerCommand('logs', '--follow=false', containerId)
                 e.standardOutput = os

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
@@ -169,7 +169,6 @@ class ComposeUp extends DefaultTask {
     Map<String, Object> getDockerInspection(String containerId) {
         new ByteArrayOutputStream().withStream { os ->
             project.exec { ExecSpec e ->
-                extension.setExecSpecWorkingDirectory(e)
                 e.environment = extension.environment
                 e.commandLine extension.dockerCommand('inspect', containerId)
                 e.standardOutput os
@@ -310,7 +309,6 @@ class ComposeUp extends DefaultTask {
         def containerId = getContainerId(serviceName)
         new ByteArrayOutputStream().withStream { os ->
             project.exec { ExecSpec e ->
-                extension.setExecSpecWorkingDirectory(e)
                 e.environment = extension.environment
                 e.commandLine extension.dockerCommand('logs', '--follow=false', containerId)
                 e.standardOutput = os


### PR DESCRIPTION
This PR allows a user to input the working directory from which docker should be invoked. The motivation for this is as follows:

* Given a root project with several subprojects
* One of those subprojects contains integration tests
* The `docker-compose.yml` file(s) live with the root project
* The `docker-compose.yml` file(s) contain relative paths to build contexts for their required images
* In the `build.gradle` file for the integration tests subproject, the docker-compose plugin is configured and points to `docker-compose.yml` files that are up a directory like `../docker-compose.yml` 
* Without this feature enhancement, `docker-compose` is executed from the integration tests subproject folder and the relative paths to the various docker build contexts defined in the compose yaml are not valid
