### PR TITLE
specify a default timeout when running docker-compose stop and allow …

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ dockerCompose {
     // executable = '/path/to/docker-compose' // allow to set the path of the docker-compose executable (usefull if not present in PATH)
     // dockerExecutable = '/path/to/docker' // allow to set the path of the docker executable (usefull if not present in PATH)
     // dockerComposeWorkingDirectory = '/path/where/docker-compose/is/invoked/from'
+    // dockerComposeStopTimeout = 10 // timeout in seconds before docker-compose sends SIGTERM to the running containers after the composeDown task has been started
     // environment.put 'BACKEND_ADDRESS', '192.168.1.100' // Pass environment variable to 'docker-compose' for substitution in compose file
 }
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ dockerCompose {
     // executable = '/path/to/docker-compose' // allow to set the path of the docker-compose executable (usefull if not present in PATH)
     // dockerExecutable = '/path/to/docker' // allow to set the path of the docker executable (usefull if not present in PATH)
     // dockerComposeWorkingDirectory = '/path/where/docker-compose/is/invoked/from'
-    // dockerComposeStopTimeout = 10 // timeout in seconds before docker-compose sends SIGTERM to the running containers after the composeDown task has been started
+    // dockerComposeStopTimeout = java.time.Duration.ofSeconds(20) // time before docker-compose sends SIGTERM to the running containers after the composeDown task has been started
     // environment.put 'BACKEND_ADDRESS', '192.168.1.100' // Pass environment variable to 'docker-compose' for substitution in compose file
 }
 

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
@@ -39,6 +39,7 @@ class ComposeExtension {
     String dockerExecutable = 'docker'
 
     String dockerComposeWorkingDirectory = null;
+    int dockerComposeStopTimeout = 10
 
     ComposeExtension(Project project, ComposeUp upTask, ComposeDown downTask) {
         this.project = project

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
@@ -39,7 +39,7 @@ class ComposeExtension {
     String dockerExecutable = 'docker'
 
     String dockerComposeWorkingDirectory = null;
-    int dockerComposeStopTimeout = 10
+    Duration dockerComposeStopTimeout = Duration.ofSeconds(10)
 
     ComposeExtension(Project project, ComposeUp upTask, ComposeDown downTask) {
         this.project = project

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDown.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDown.groovy
@@ -21,7 +21,7 @@ class ComposeDown extends DefaultTask {
             project.exec { ExecSpec e ->
                 extension.setExecSpecWorkingDirectory(e)
                 e.environment = extension.environment
-                String[] args = ['stop', '--timeout', extension.dockerComposeStopTimeout]
+                String[] args = ['stop', '--timeout', extension.dockerComposeStopTimeout.getSeconds()]
                 e.commandLine extension.composeCommand(args)
             }
             if (extension.removeContainers) {

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDown.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDown.groovy
@@ -21,7 +21,8 @@ class ComposeDown extends DefaultTask {
             project.exec { ExecSpec e ->
                 extension.setExecSpecWorkingDirectory(e)
                 e.environment = extension.environment
-                e.commandLine extension.composeCommand('stop')
+                String[] args = ['stop', '--timeout', extension.dockerComposeStopTimeout]
+                e.commandLine extension.composeCommand(args)
             }
             if (extension.removeContainers) {
                 if (extension.getDockerComposeVersion() >= VersionNumber.parse('1.6.0')) {


### PR DESCRIPTION
…it to be configurable


motivation:

we have applications which take longer than the default of 10 seconds to shut down completely. Without this timeout, the composeDown task reports a failure as the containers did not shut down gracefully. This causes false negatives on build results.