### PR TITLE
Support for scale

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: generic
 
 sudo: required
 env:
-  - DOCKER_VERSION=1.13.1 DOCKER_PACKAGE_VERSION=$DOCKER_VERSION-0~ubuntu-precise
-  - DOCKER_VERSION=1.12.6 DOCKER_PACKAGE_VERSION=$DOCKER_VERSION-0~ubuntu-precise
-  - DOCKER_VERSION=1.11.2 DOCKER_PACKAGE_VERSION=$DOCKER_VERSION-0~precise
+  - DOCKER_VERSION=1.13.1 DOCKER_PACKAGE_VERSION=$DOCKER_VERSION-0~ubuntu-precise DOCKER_COMPOSE_VERSION=1.13.0
+  - DOCKER_VERSION=1.13.1 DOCKER_PACKAGE_VERSION=$DOCKER_VERSION-0~ubuntu-precise DOCKER_COMPOSE_VERSION=1.11.2
+  - DOCKER_VERSION=1.12.6 DOCKER_PACKAGE_VERSION=$DOCKER_VERSION-0~ubuntu-precise DOCKER_COMPOSE_VERSION=1.11.2
+  - DOCKER_VERSION=1.11.2 DOCKER_PACKAGE_VERSION=$DOCKER_VERSION-0~precise DOCKER_COMPOSE_VERSION=1.11.2
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
@@ -18,10 +19,10 @@ before_install:
   - curl -sSL https://get.docker.com/ | sh
   - sudo apt-get -y --force-yes install docker-engine=$DOCKER_PACKAGE_VERSION
   # Build image with building environment
-  - sudo docker build --tag=build-image .
+  - sudo docker build --build-arg DOCKER_COMPOSE_VERSION=$DOCKER_COMPOSE_VERSION --tag=build-image .
 
 script:
-  - sudo docker run -v $(pwd):/build -v $HOME/.m2:/root/.m2 -v $HOME/.gradle:/root/.gradle -v /var/run/docker.sock:/var/run/docker.sock build-image test --info
+  - sudo docker run -v $(pwd):/build -v $HOME/.m2:/root/.m2 -v $HOME/.gradle:/root/.gradle -v /var/run/docker.sock:/var/run/docker.sock build-image test -PDOCKER_COMPOSE_VERSION=$DOCKER_COMPOSE_VERSION --info
 
 after_success:
-  - test $TRAVIS_PULL_REQUEST == "false" && test "$TRAVIS_TAG" != "" && test $TRAVIS_REPO_SLUG == "avast/docker-compose-gradle-plugin" && test $DOCKER_VERSION == "1.13.1" && sudo docker run -v $(pwd):/build -v $HOME/.m2:/root/.m2 -v $HOME/.gradle:/root/.gradle -v /var/run/docker.sock:/var/run/docker.sock -e "BINTRAY_USER=$BINTRAY_USER" -e "BINTRAY_KEY=$BINTRAY_KEY" -e "GRADLE_PORTAL_KEY=$GRADLE_PORTAL_KEY" -e "GRADLE_PORTAL_SECRET=$GRADLE_PORTAL_SECRET" build-image bintrayUpload publishPlugins -Pversion="$TRAVIS_TAG" --info
+  - test $TRAVIS_PULL_REQUEST == "false" && test "$TRAVIS_TAG" != "" && test $TRAVIS_REPO_SLUG == "avast/docker-compose-gradle-plugin" && test $DOCKER_VERSION == "1.13.1" && test $DOCKER_COMPOSE_VERSION == "1.13.0" && sudo docker run -v $(pwd):/build -v $HOME/.m2:/root/.m2 -v $HOME/.gradle:/root/.gradle -v /var/run/docker.sock:/var/run/docker.sock -e "BINTRAY_USER=$BINTRAY_USER" -e "BINTRAY_KEY=$BINTRAY_KEY" -e "GRADLE_PORTAL_KEY=$GRADLE_PORTAL_KEY" -e "GRADLE_PORTAL_SECRET=$GRADLE_PORTAL_SECRET" build-image bintrayUpload publishPlugins -Pversion="$TRAVIS_TAG" --info

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@
 FROM java:8u111-jdk-alpine
 MAINTAINER augustyn@avast.com
 
-RUN apk add --update libstdc++ docker=1.11.2-r1 py-pip=8.1.2-r0 && rm -rf /var/cache/apk/* && pip install --no-cache-dir docker-compose==1.11.2
+ARG DOCKER_COMPOSE_VERSION=1.11.2
+ENV DOCKER_COMPOSE_VERSION=$DOCKER_COMPOSE_VERSION
+
+RUN apk add --update libstdc++ docker=1.11.2-r1 py-pip=8.1.2-r0 && rm -rf /var/cache/apk/* && pip install --no-cache-dir docker-compose==$DOCKER_COMPOSE_VERSION
 
 # allow to bind local Docker to the outer Docker
 VOLUME /var/run/docker.sock

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ dockerCompose {
     // dockerComposeWorkingDirectory = '/path/where/docker-compose/is/invoked/from'
     // dockerComposeStopTimeout = java.time.Duration.ofSeconds(20) // time before docker-compose sends SIGTERM to the running containers after the composeDown task has been started
     // environment.put 'BACKEND_ADDRESS', '192.168.1.100' // Pass environment variable to 'docker-compose' for substitution in compose file
-    // scale = [${serviceName1}: 5, ${serviceName2}: 2] // Pass docker compose --scale option like 'docker-compose up --scale SERVICE1=NUM --scale SERVICE2=NUM'
+    // scale = [${serviceName1}: 5, ${serviceName2}: 2] // Pass docker compose --scale option like 'docker-compose up --scale serviceName1=5 --scale serviceName2=2'
 }
 
 test.doFirst {
@@ -70,8 +70,8 @@ test.doFirst {
     // if service is scaled using scale option, environment variables will be exposed for each service instance like "web_1.host", "web_1.tcp.80", "web_2.host", "web_2.tcp.80" and so on
     dockerCompose.exposeAsSystemProperties(test)
     // get information about container of service `web` (declared in docker-compose.yml)
-    def webInfo = dockerCompose.servicesInfos.web.serviceInstanceInfos[0]
-    // in case scale option is used, serviceInstanceInfos will contain information about all instances of scaled service. Particular service can be retreived either by iterating the serviceInstanceInfos list or using getInstanceByName() method
+    def webInfo = dockerCompose.servicesInfos.web.firstInstance
+    // in case scale option is used, serviceInstanceInfos will contain information about all running containers of service. Particular container can be retreived either by iterating the values of serviceInstanceInfos map, getting particular service by key like 'web_1' or using getInstanceByName() method
     def webInfo = dockerCompose.servicesInfos.web.getInstanceByName('web_1')
     // pass host and exposed TCP port 80 as custom-named Java System properties
     systemProperty 'myweb.host', webInfo.host

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ dockerCompose {
     // dockerComposeWorkingDirectory = '/path/where/docker-compose/is/invoked/from'
     // dockerComposeStopTimeout = java.time.Duration.ofSeconds(20) // time before docker-compose sends SIGTERM to the running containers after the composeDown task has been started
     // environment.put 'BACKEND_ADDRESS', '192.168.1.100' // Pass environment variable to 'docker-compose' for substitution in compose file
+    // scale = [${serviceName1}: 5, ${serviceName2}: 2] // Pass docker compose --scale option like 'docker-compose up --scale SERVICE1=NUM --scale SERVICE2=NUM'
 }
 
 test.doFirst {

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
@@ -26,6 +26,7 @@ class ComposeExtension {
     Duration waitAfterHealthyStateProbeFailure = Duration.ofSeconds(5)
     Duration waitForHealthyStateTimeout = Duration.ofMinutes(15)
     List<String> useComposeFiles = []
+    Map<String, Integer> scale = [:]
     String projectName = null
 
     boolean stopContainers = true
@@ -35,11 +36,11 @@ class ComposeExtension {
     boolean removeOrphans = false
 
     String executable = 'docker-compose'
-    Map<String, Object> environment = new HashMap<String, Object>(System.getenv());
+    Map<String, Object> environment = new HashMap<String, Object>(System.getenv())
 
     String dockerExecutable = 'docker'
 
-    String dockerComposeWorkingDirectory = null;
+    String dockerComposeWorkingDirectory = null
     Duration dockerComposeStopTimeout = Duration.ofSeconds(10)
 
     ComposeExtension(Project project, ComposeUp upTask, ComposeDown downTask) {
@@ -124,6 +125,10 @@ class ComposeExtension {
 
     boolean removeOrphans() {
         getDockerComposeVersion() >= VersionNumber.parse('1.7.0') && this.removeOrphans
+    }
+    
+    boolean scale() {
+        getDockerComposeVersion() >= VersionNumber.parse('1.13.0') && this.scale
     }
 }
 

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
@@ -64,22 +64,22 @@ class ComposeExtension {
 
     void exposeAsEnvironment(ProcessForkOptions task) {
         servicesInfos.values().each { serviceInfo ->
-            serviceInfo.serviceInstanceInfos.each { si ->
-                if (si.instanceName.endsWith('_1')) {
+            serviceInfo.serviceInstanceInfos.each { instanceName, si ->
+                if (instanceName.endsWith('_1')) {
                     task.environment << createEnvironmentVariables(serviceInfo.name.toUpperCase(), si)
                 }
-                task.environment << createEnvironmentVariables(si.instanceName.toUpperCase(), si)
+                task.environment << createEnvironmentVariables(instanceName.toUpperCase(), si)
             }
         }
     }
 
     void exposeAsSystemProperties(JavaForkOptions task) {
         servicesInfos.values().each { serviceInfo ->
-            serviceInfo.serviceInstanceInfos.each { si ->
-                if(si.instanceName.endsWith('_1')) {
+            serviceInfo.serviceInstanceInfos.each { instanceName, si ->
+                if(instanceName.endsWith('_1')) {
                     task.systemProperties << createSystemProperties(serviceInfo.name, si)
                 }
-                task.systemProperties << createSystemProperties(si.instanceName, si)
+                task.systemProperties << createSystemProperties(instanceName, si)
             }
         }
     }

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
@@ -63,21 +63,25 @@ class ComposeExtension {
     }
 
     void exposeAsEnvironment(ProcessForkOptions task) {
-        servicesInfos.values().each { si ->
-            task.environment.put("${si.name.toUpperCase()}_HOST".toString(), si.host)
-            task.environment.put("${si.name.toUpperCase()}_CONTAINER_HOSTNAME".toString(), si.containerHostname)
-            si.tcpPorts.each {
-                task.environment.put("${si.name.toUpperCase()}_TCP_${it.key}".toString(), it.value)
+        servicesInfos.values().each { serviceInfo ->
+            serviceInfo.serviceInstanceInfos.each { si ->
+                task.environment.put("${si.instanceName.toUpperCase()}_HOST".toString(), si.host)
+                task.environment.put("${si.instanceName.toUpperCase()}_CONTAINER_HOSTNAME".toString(), si.containerHostname)
+                si.tcpPorts.each {
+                    task.environment.put("${si.instanceName.toUpperCase()}_TCP_${it.key}".toString(), it.value)
+                }
             }
         }
     }
 
     void exposeAsSystemProperties(JavaForkOptions task) {
-        servicesInfos.values().each { si ->
-            task.systemProperties.put("${si.name}.host".toString(), si.host)
-            task.systemProperties.put("${si.name}.containerHostname".toString(), si.containerHostname)
-            si.tcpPorts.each {
-                task.systemProperties.put("${si.name}.tcp.${it.key}".toString(), it.value)
+        servicesInfos.values().each { serviceInfo ->
+            serviceInfo.serviceInstanceInfos.each { si ->
+                task.systemProperties.put("${si.instanceName}.host".toString(), si.host)
+                task.systemProperties.put("${si.instanceName}.containerHostname".toString(), si.containerHostname)
+                si.tcpPorts.each {
+                    task.systemProperties.put("${si.instanceName}.tcp.${it.key}".toString(), it.value)
+                }
             }
         }
     }

--- a/src/main/groovy/com/avast/gradle/dockercompose/ServiceInfo.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ServiceInfo.groovy
@@ -7,10 +7,10 @@ class ServiceInfo {
     String name
     Map<String, ServiceInstanceInfo> serviceInstanceInfos = [:]
 
-    String getHost() { serviceInstanceInfos.values().first().serviceHost.host }
-    Map<Integer, Integer> getPorts() { serviceInstanceInfos.values().first().tcpPorts }
+    String getHost() { firstInstance.serviceHost.host }
+    Map<Integer, Integer> getPorts() { firstInstance.tcpPorts }
     Integer getPort() { ports.values().first() }
-    Integer getTcpPort() { serviceInstanceInfos.values().first().tcpPorts.values().first() }
+    Integer getTcpPort() { firstInstance.tcpPorts.values().first() }
     
     ServiceInstanceInfo getFirstInstance() {
         serviceInstanceInfos.values().first()

--- a/src/main/groovy/com/avast/gradle/dockercompose/ServiceInfo.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ServiceInfo.groovy
@@ -5,14 +5,18 @@ import groovy.transform.Immutable
 @Immutable
 class ServiceInfo {
     String name
-    List<ServiceInstanceInfo> serviceInstanceInfos = []
+    Map<String, ServiceInstanceInfo> serviceInstanceInfos = [:]
 
-    String getHost() { serviceInstanceInfos[0].serviceHost.host }
-    Map<Integer, Integer> getPorts() { serviceInstanceInfos[0].tcpPorts }
+    String getHost() { serviceInstanceInfos.values().first().serviceHost.host }
+    Map<Integer, Integer> getPorts() { serviceInstanceInfos.values().first().tcpPorts }
     Integer getPort() { ports.values().first() }
-    Integer getTcpPort() { serviceInstanceInfos[0].tcpPorts.values().first() }
+    Integer getTcpPort() { serviceInstanceInfos.values().first().tcpPorts.values().first() }
+    
+    ServiceInstanceInfo getFirstInstance() {
+        serviceInstanceInfos.values().first()
+    }
     
     ServiceInstanceInfo getInstanceByName(String name) {
-        serviceInstanceInfos.find { it.instanceName == name }
+        serviceInstanceInfos.get(name)
     }
 }

--- a/src/main/groovy/com/avast/gradle/dockercompose/ServiceInfo.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ServiceInfo.groovy
@@ -1,8 +1,16 @@
 package com.avast.gradle.dockercompose
 
+import groovy.transform.Immutable
+
+@Immutable
 class ServiceInfo {
     String name
     List<ServiceInstanceInfo> serviceInstanceInfos = []
+
+    String getHost() { serviceInstanceInfos[0].serviceHost.host }
+    Map<Integer, Integer> getPorts() { serviceInstanceInfos[0].tcpPorts }
+    Integer getPort() { ports.values().first() }
+    Integer getTcpPort() { serviceInstanceInfos[0].tcpPorts.values().first() }
     
     ServiceInstanceInfo getInstanceByName(String name) {
         serviceInstanceInfos.find { it.instanceName == name }

--- a/src/main/groovy/com/avast/gradle/dockercompose/ServiceInfo.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ServiceInfo.groovy
@@ -1,20 +1,10 @@
 package com.avast.gradle.dockercompose
 
-import groovy.transform.Immutable
-
-@Immutable
 class ServiceInfo {
     String name
-    ServiceHost serviceHost
-    /* Mapping from exposed to forwarded port. */
-    Map<Integer, Integer> tcpPorts
-    String containerHostname
-    /* Docker inspection */
-    Map<String, Object> inspection
-    String getContainerId() { inspection.Id }
-
-    String getHost() { serviceHost.host }
-    Map<Integer, Integer> getPorts() { tcpPorts }
-    Integer getPort() { ports.values().first() }
-    Integer getTcpPort() { tcpPorts.values().first() }
+    List<ServiceInstanceInfo> serviceInstanceInfos = []
+    
+    ServiceInstanceInfo getInstanceByName(String name) {
+        serviceInstanceInfos.find { it.instanceName == name }
+    }
 }

--- a/src/main/groovy/com/avast/gradle/dockercompose/ServiceInstanceInfo.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ServiceInstanceInfo.groovy
@@ -1,0 +1,20 @@
+package com.avast.gradle.dockercompose
+
+import groovy.transform.Immutable
+
+@Immutable
+class ServiceInstanceInfo {
+    String instanceName
+    ServiceHost serviceHost
+    /* Mapping from exposed to forwarded port. */
+    Map<Integer, Integer> tcpPorts
+    String containerHostname
+    /* Docker inspection */
+    Map<String, Object> inspection
+    String getContainerId() { inspection.Id }
+
+    String getHost() { serviceHost.host }
+    Map<Integer, Integer> getPorts() { tcpPorts }
+    Integer getPort() { ports.values().first() }
+    Integer getTcpPort() { tcpPorts.values().first() }
+}

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
@@ -109,7 +109,6 @@ class ComposeUp extends DefaultTask {
     }
 
     protected ServiceInfo createServiceInfo(String serviceName) {
-        String defaultProjectName = extension.projectName ?: new File(System.getProperty('user.dir')).name
         Iterable<String> containerIds = getContainerIds(serviceName)
         ServiceInfo serviceInfo = new ServiceInfo(name: serviceName)
         containerIds.each { String containerId ->

--- a/src/test/groovy/com/avast/gradle/dockercompose/DockerComposePluginTest.groovy
+++ b/src/test/groovy/com/avast/gradle/dockercompose/DockerComposePluginTest.groovy
@@ -7,19 +7,22 @@ import org.gradle.api.Task
 import org.gradle.api.internal.file.TmpDirTemporaryFileProvider
 import org.gradle.api.tasks.testing.Test
 import org.gradle.testfixtures.ProjectBuilder
+import org.gradle.util.VersionNumber
 import spock.lang.IgnoreIf
 import spock.lang.Specification
 
 class DockerComposePluginTest extends Specification {
+    String projectName = 'test'
+
     def "add tasks and extension to the project"() {
         def project = ProjectBuilder.builder().build()
         when:
-        project.plugins.apply 'docker-compose'
+            project.plugins.apply 'docker-compose'
         then:
-        project.tasks.composeUp instanceof ComposeUp
-        project.tasks.composeDown instanceof ComposeDown
-        project.tasks.composePull instanceof ComposePull
-        project.extensions.findByName('dockerCompose') instanceof ComposeExtension
+            project.tasks.composeUp instanceof ComposeUp
+            project.tasks.composeDown instanceof ComposeDown
+            project.tasks.composePull instanceof ComposePull
+            project.extensions.findByName('dockerCompose') instanceof ComposeExtension
     }
 
     def "dockerCompose.isRequiredBy() adds dependencies"() {
@@ -27,10 +30,10 @@ class DockerComposePluginTest extends Specification {
         project.plugins.apply 'docker-compose'
         Task task = project.tasks.create('integrationTest')
         when:
-        project.dockerCompose.isRequiredBy(task)
+            project.dockerCompose.isRequiredBy(task)
         then:
-        task.dependsOn.contains(project.tasks.composeUp)
-        task.getFinalizedBy().getDependencies(task).any { it == project.tasks.composeDown }
+            task.dependsOn.contains(project.tasks.composeUp)
+            task.getFinalizedBy().getDependencies(task).any { it == project.tasks.composeDown }
     }
 
     def "isRequiredBy ensures right order of tasks"() {
@@ -38,10 +41,10 @@ class DockerComposePluginTest extends Specification {
         project.plugins.apply 'docker-compose'
         project.plugins.apply 'java'
         when:
-        project.dockerCompose.isRequiredBy(project.tasks.test)
+            project.dockerCompose.isRequiredBy(project.tasks.test)
         then:
-        project.tasks.composeUp.shouldRunAfter.values.any { it == project.tasks.testClasses }
-        noExceptionThrown()
+            project.tasks.composeUp.shouldRunAfter.values.any { it == project.tasks.testClasses }
+            noExceptionThrown()
     }
 
     def "allows usage from integration test"() {
@@ -55,25 +58,27 @@ class DockerComposePluginTest extends Specification {
         '''
         def project = ProjectBuilder.builder().withProjectDir(projectDir).build()
         project.plugins.apply 'docker-compose'
+        def extension = (ComposeExtension) project.extensions.findByName('dockerCompose')
+        extension.projectName = projectName
         project.tasks.create('integrationTest').doLast {
-            ServiceInfo webInfo = project.dockerCompose.servicesInfos.web
+            ServiceInfo webInfo = project.dockerCompose.servicesInfos."${projectName}_web_1"
             assert "http://${webInfo.host}:${webInfo.tcpPorts[80]}".toURL().text.contains('nginx')
             assert webInfo.ports == webInfo.tcpPorts
             assert !webInfo.containerHostname.isEmpty()
             assert webInfo.inspection.size() > 0
         }
         when:
-        project.tasks.composeUp.up()
-        project.tasks.integrationTest.execute()
+            project.tasks.composeUp.up()
+            project.tasks.integrationTest.execute()
         then:
-        noExceptionThrown()
+            noExceptionThrown()
         cleanup:
-        project.tasks.composeDown.down()
-        try {
-            projectDir.delete()
-        } catch(ignored) {
-            projectDir.deleteOnExit()
-        }
+            project.tasks.composeDown.down()
+            try {
+                projectDir.delete()
+            } catch (ignored) {
+                projectDir.deleteOnExit()
+            }
     }
 
     def "allows pull from integration test"() {
@@ -88,15 +93,15 @@ class DockerComposePluginTest extends Specification {
         def project = ProjectBuilder.builder().withProjectDir(projectDir).build()
         project.plugins.apply 'docker-compose'
         when:
-        project.tasks.composePull.pull()
+            project.tasks.composePull.pull()
         then:
-        noExceptionThrown()
+            noExceptionThrown()
         cleanup:
-        try {
-            projectDir.delete()
-        } catch(ignored) {
-            projectDir.deleteOnExit()
-        }
+            try {
+                projectDir.delete()
+            } catch (ignored) {
+                projectDir.deleteOnExit()
+            }
     }
 
     def "can specify compose files to use"() {
@@ -115,25 +120,26 @@ class DockerComposePluginTest extends Specification {
         def project = ProjectBuilder.builder().withProjectDir(projectDir).build()
         project.plugins.apply 'docker-compose'
         def extension = (ComposeExtension) project.extensions.findByName('dockerCompose')
+        extension.projectName = projectName
         project.tasks.create('integrationTest').doLast {
-            ServiceInfo webInfo = project.dockerCompose.servicesInfos.web
+            ServiceInfo webInfo = project.dockerCompose.servicesInfos."${projectName}_web_1"
             assert webInfo.ports.containsKey(8080)
             assert webInfo.ports.containsKey(80)
         }
         when:
-        extension.waitForTcpPorts = false // port 8080 is a fake
-        extension.useComposeFiles = ['original.yml', 'override.yml']
-        project.tasks.composeUp.up()
-        project.tasks.integrationTest.execute()
+            extension.waitForTcpPorts = false // port 8080 is a fake
+            extension.useComposeFiles = ['original.yml', 'override.yml']
+            project.tasks.composeUp.up()
+            project.tasks.integrationTest.execute()
         then:
-        noExceptionThrown()
+            noExceptionThrown()
         cleanup:
-        project.tasks.composeDown.down()
-        try {
-            projectDir.delete()
-        } catch(ignored) {
-            projectDir.deleteOnExit()
-        }
+            project.tasks.composeDown.down()
+            try {
+                projectDir.delete()
+            } catch (ignored) {
+                projectDir.deleteOnExit()
+            }
 
     }
 
@@ -154,22 +160,24 @@ class DockerComposePluginTest extends Specification {
         '''
         def project = ProjectBuilder.builder().withProjectDir(projectDir).build()
         project.plugins.apply 'docker-compose'
+        def extension = (ComposeExtension) project.extensions.findByName('dockerCompose')
+        extension.projectName = projectName
         project.tasks.create('integrationTest').doLast {
-            assert project.dockerCompose.servicesInfos.web.ports.containsKey(80)
-            assert project.dockerCompose.servicesInfos.devweb.ports.containsKey(80)
+            assert project.dockerCompose.servicesInfos."${projectName}_web_1".ports.containsKey(80)
+            assert project.dockerCompose.servicesInfos."${projectName}_devweb_1".ports.containsKey(80)
         }
         when:
-        project.tasks.composeUp.up()
-        project.tasks.integrationTest.execute()
+            project.tasks.composeUp.up()
+            project.tasks.integrationTest.execute()
         then:
-        noExceptionThrown()
+            noExceptionThrown()
         cleanup:
-        project.tasks.composeDown.down()
-        try {
-            projectDir.delete()
-        } catch(ignored) {
-            projectDir.deleteOnExit()
-        }
+            project.tasks.composeDown.down()
+            try {
+                projectDir.delete()
+            } catch (ignored) {
+                projectDir.deleteOnExit()
+            }
     }
 
     def "docker-compose.override.yml file ignored when files are specified"() {
@@ -195,26 +203,27 @@ class DockerComposePluginTest extends Specification {
         def project = ProjectBuilder.builder().withProjectDir(projectDir).build()
         project.plugins.apply 'docker-compose'
         def extension = (ComposeExtension) project.extensions.findByName('dockerCompose')
+        extension.projectName = projectName
         project.tasks.create('integrationTest').doLast {
-            ServiceInfo webInfo = project.dockerCompose.servicesInfos.web
+            ServiceInfo webInfo = project.dockerCompose.servicesInfos."${projectName}_web_1"
             assert webInfo.ports.containsKey(8080)
             assert !webInfo.ports.containsKey(80)
             assert !project.dockerCompose.servicesInfos.devweb
         }
         when:
-        extension.waitForTcpPorts = false // port 8080 is a fake
-        extension.useComposeFiles = ['docker-compose.yml', 'docker-compose.prod.yml']
-        project.tasks.composeUp.up()
-        project.tasks.integrationTest.execute()
+            extension.waitForTcpPorts = false // port 8080 is a fake
+            extension.useComposeFiles = ['docker-compose.yml', 'docker-compose.prod.yml']
+            project.tasks.composeUp.up()
+            project.tasks.integrationTest.execute()
         then:
-        noExceptionThrown()
+            noExceptionThrown()
         cleanup:
-        project.tasks.composeDown.down()
-        try {
-            projectDir.delete()
-        } catch(ignored) {
-            projectDir.deleteOnExit()
-        }
+            project.tasks.composeDown.down()
+            try {
+                projectDir.delete()
+            } catch (ignored) {
+                projectDir.deleteOnExit()
+            }
     }
 
     def "exposes environment variables and system properties"() {
@@ -223,28 +232,30 @@ class DockerComposePluginTest extends Specification {
         def project = ProjectBuilder.builder().withProjectDir(projectDir).build()
         project.plugins.apply 'java'
         project.plugins.apply 'docker-compose'
+        def extension = (ComposeExtension) project.extensions.findByName('dockerCompose')
+        extension.projectName = projectName
         project.tasks.composeUp.up()
         Test test = project.tasks.test as Test
         when:
-        project.dockerCompose.exposeAsEnvironment(test)
-        project.dockerCompose.exposeAsSystemProperties(test)
+            project.dockerCompose.exposeAsEnvironment(test)
+            project.dockerCompose.exposeAsSystemProperties(test)
         then:
-        test.environment.containsKey('WEB_HOST')
-        test.environment.containsKey('WEB_CONTAINER_HOSTNAME')
-        test.environment.containsKey('WEB_TCP_80')
-        test.systemProperties.containsKey('web.host')
-        test.systemProperties.containsKey('web.containerHostname')
-        test.systemProperties.containsKey('web.tcp.80')
+            test.environment.containsKey('TEST_WEB_1_HOST')
+            test.environment.containsKey('TEST_WEB_1_CONTAINER_HOSTNAME')
+            test.environment.containsKey('TEST_WEB_1_TCP_80')
+            test.systemProperties.containsKey('test_web_1.host')
+            test.systemProperties.containsKey('test_web_1.containerHostname')
+            test.systemProperties.containsKey('test_web_1.tcp.80')
         cleanup:
-        project.tasks.composeDown.down()
-        try {
-            projectDir.delete()
-        } catch(ignored) {
-            projectDir.deleteOnExit()
-        }
+            project.tasks.composeDown.down()
+            try {
+                projectDir.delete()
+            } catch (ignored) {
+                projectDir.deleteOnExit()
+            }
         where:
-        // test it for both compose file version 1 and 2
-        composeFileContent << ['''
+            // test it for both compose file version 1 and 2
+            composeFileContent << ['''
             web:
                 image: nginx
                 ports:
@@ -274,21 +285,23 @@ class DockerComposePluginTest extends Specification {
         def project = ProjectBuilder.builder().withProjectDir(projectDir).build()
         project.plugins.apply 'java'
         project.plugins.apply 'docker-compose'
+        def extension = (ComposeExtension) project.extensions.findByName('dockerCompose')
+        extension.projectName = projectName
         project.tasks.composeUp.up()
         Test test = project.tasks.test as Test
         when:
-        project.dockerCompose.exposeAsEnvironment(test)
-        project.dockerCompose.exposeAsSystemProperties(test)
+            project.dockerCompose.exposeAsEnvironment(test)
+            project.dockerCompose.exposeAsSystemProperties(test)
         then:
-        test.environment.get('WEB_HOST') == 'localhost'
-        test.systemProperties.get('web.host') == 'localhost'
+            test.environment.get('TEST_WEB_1_HOST') == 'localhost'
+            test.systemProperties.get('test_web_1.host') == 'localhost'
         cleanup:
-        project.tasks.composeDown.down()
-        try {
-            projectDir.delete()
-        } catch(ignored) {
-            projectDir.deleteOnExit()
-        }
+            project.tasks.composeDown.down()
+            try {
+                projectDir.delete()
+            } catch (ignored) {
+                projectDir.deleteOnExit()
+            }
     }
 
     def "reads logs of service"() {
@@ -299,18 +312,21 @@ class DockerComposePluginTest extends Specification {
         '''
         def project = ProjectBuilder.builder().withProjectDir(projectDir).build()
         project.plugins.apply 'docker-compose'
+        def extension = (ComposeExtension) project.extensions.findByName('dockerCompose')
+        extension.projectName = projectName
         project.tasks.composeUp.up()
+        String containerId = project.dockerCompose.servicesInfos."${projectName}_hello_1".containerId
         when:
-        String output = project.tasks.composeUp.getServiceLogs('hello')
+            String output = project.tasks.composeUp.getServiceLogs(containerId)
         then:
-        output.contains('Hello from Docker')
+            output.contains('Hello from Docker')
         cleanup:
-        project.tasks.composeDown.down()
-        try {
-            projectDir.delete()
-        } catch(ignored) {
-            projectDir.deleteOnExit()
-        }
+            project.tasks.composeDown.down()
+            try {
+                projectDir.delete()
+            } catch (ignored) {
+                projectDir.deleteOnExit()
+            }
     }
 
     def "docker-compose substitutes environment variables"() {
@@ -324,24 +340,61 @@ class DockerComposePluginTest extends Specification {
         def project = ProjectBuilder.builder().withProjectDir(projectDir).build()
         project.plugins.apply 'docker-compose'
         def extension = (ComposeExtension) project.extensions.findByName('dockerCompose')
+        extension.projectName = projectName
         project.tasks.create('integrationTest').doLast {
-            ServiceInfo webInfo = project.dockerCompose.servicesInfos.web
+            ServiceInfo webInfo = project.dockerCompose.servicesInfos."${projectName}_web_1"
             assert webInfo.ports.containsKey(80)
         }
         when:
-        extension.useComposeFiles = ['docker-compose.yml']
-        extension.environment.put 'MY_WEB_PORT', 80
-        extension.waitForTcpPorts = false  // checked in assert
-        project.tasks.composeUp.up()
-        project.tasks.integrationTest.execute()
+            extension.useComposeFiles = ['docker-compose.yml']
+            extension.environment.put 'MY_WEB_PORT', 80
+            extension.waitForTcpPorts = false  // checked in assert
+            project.tasks.composeUp.up()
+            project.tasks.integrationTest.execute()
         then:
-        noExceptionThrown()
+            noExceptionThrown()
         cleanup:
-        project.tasks.composeDown.down()
-        try {
-            projectDir.delete()
-        } catch(ignored) {
-            projectDir.deleteOnExit()
+            project.tasks.composeDown.down()
+            try {
+                projectDir.delete()
+            } catch (ignored) {
+                projectDir.deleteOnExit()
+            }
+    }
+
+    def "docker-compose scale option launches multiple instances of service with compose 1.13.0+"() {
+        def projectDir = new TmpDirTemporaryFileProvider().createTemporaryDirectory("gradle", "projectDir")
+        new File(projectDir, 'docker-compose.yml') << '''
+            web:
+                image: nginx
+                command: bash -c "sleep 5 && nginx -g 'daemon off;'"
+                ports:
+                  - 80
+        '''
+        def project = ProjectBuilder.builder().withProjectDir(projectDir).build()
+        project.plugins.apply 'docker-compose'
+        def extension = (ComposeExtension) project.extensions.findByName('dockerCompose')
+        Integer scale = 2
+        extension.scale = ['web': scale]
+        project.tasks.create('integrationTest').doLast {
+            def webInfos = project.dockerCompose.servicesInfos
+            if (extension.scale()) {
+                assert webInfos.size() == scale
+            } else {
+                assert webInfos.size() == 1
+            }
         }
+        when:
+            project.tasks.composeUp.up()
+            project.tasks.integrationTest.execute()
+        then:
+            noExceptionThrown()
+        cleanup:
+            project.tasks.composeDown.down()
+            try {
+                projectDir.delete()
+            } catch (ignored) {
+                projectDir.deleteOnExit()
+            }
     }
 }

--- a/src/test/groovy/com/avast/gradle/dockercompose/DockerComposePluginTest.groovy
+++ b/src/test/groovy/com/avast/gradle/dockercompose/DockerComposePluginTest.groovy
@@ -352,7 +352,7 @@ class DockerComposePluginTest extends Specification {
             }
     }
 
-    @IgnoreIf( {parse(System.getenv('DOCKER_COMPOSE_VERSION')) >= parse('1.13.0')} )
+    @IgnoreIf({ parse(System.getenv('DOCKER_COMPOSE_VERSION')) >= parse('1.13.0') })
     def "exception is thrown for scale option if unsupported docker-compose is used"() {
         def projectDir = new TmpDirTemporaryFileProvider().createTemporaryDirectory("gradle", "projectDir")
         new File(projectDir, 'docker-compose.yml') << '''
@@ -378,7 +378,7 @@ class DockerComposePluginTest extends Specification {
             }
     }
 
-    @IgnoreIf( {parse(System.getenv('DOCKER_COMPOSE_VERSION')) < parse('1.13.0')} )
+    @IgnoreIf({ parse(System.getenv('DOCKER_COMPOSE_VERSION')) < parse('1.13.0') })
     def "docker-compose scale option launches multiple instances of service"() {
         def projectDir = new TmpDirTemporaryFileProvider().createTemporaryDirectory("gradle", "projectDir")
         new File(projectDir, 'docker-compose.yml') << '''
@@ -409,7 +409,7 @@ class DockerComposePluginTest extends Specification {
             }
     }
 
-    @IgnoreIf( {parse(System.getenv('DOCKER_COMPOSE_VERSION')) < parse('1.13.0')} )
+    @IgnoreIf({ parse(System.getenv('DOCKER_COMPOSE_VERSION')) < parse('1.13.0') })
     def "environment variables and system properties exposed for all scaled containers"() {
         def projectDir = new TmpDirTemporaryFileProvider().createTemporaryDirectory("gradle", "projectDir")
         new File(projectDir, 'docker-compose.yml') << '''
@@ -429,12 +429,14 @@ class DockerComposePluginTest extends Specification {
             project.dockerCompose.exposeAsEnvironment(test)
             project.dockerCompose.exposeAsSystemProperties(test)
         then:
-            test.environment.containsKey("WEB_${containerInstance}_HOST".toString())
-            test.environment.containsKey("WEB_${containerInstance}_CONTAINER_HOSTNAME".toString())
-            test.environment.containsKey("WEB_${containerInstance}_TCP_80".toString())
-            test.systemProperties.containsKey("web_${containerInstance}.host".toString())
-            test.systemProperties.containsKey("web_${containerInstance}.containerHostname".toString())
-            test.systemProperties.containsKey("web_${containerInstance}.tcp.80".toString())
+            [1, 2].each { containerInstance ->
+                assert test.environment.containsKey("WEB_${containerInstance}_HOST".toString())
+                assert test.environment.containsKey("WEB_${containerInstance}_CONTAINER_HOSTNAME".toString())
+                assert test.environment.containsKey("WEB_${containerInstance}_TCP_80".toString())
+                assert test.systemProperties.containsKey("web_${containerInstance}.host".toString())
+                assert test.systemProperties.containsKey("web_${containerInstance}.containerHostname".toString())
+                assert test.systemProperties.containsKey("web_${containerInstance}.tcp.80".toString())
+            }
         cleanup:
             project.tasks.composeDown.down()
             try {
@@ -442,7 +444,5 @@ class DockerComposePluginTest extends Specification {
             } catch (ignored) {
                 projectDir.deleteOnExit()
             }
-        where:
-            containerInstance << [1, 2]
     }
 }

--- a/src/test/groovy/com/avast/gradle/dockercompose/DockerComposePluginTest.groovy
+++ b/src/test/groovy/com/avast/gradle/dockercompose/DockerComposePluginTest.groovy
@@ -60,7 +60,7 @@ class DockerComposePluginTest extends Specification {
         def project = ProjectBuilder.builder().withProjectDir(projectDir).build()
         project.plugins.apply 'docker-compose'
         project.tasks.create('integrationTest').doLast {
-            ServiceInstanceInfo webInfo = project.dockerCompose.servicesInfos."web".serviceInstanceInfos[0]
+            ServiceInstanceInfo webInfo = project.dockerCompose.servicesInfos.web.firstInstance
             assert "http://${webInfo.host}:${webInfo.tcpPorts[80]}".toURL().text.contains('nginx')
             assert webInfo.ports == webInfo.tcpPorts
             assert !webInfo.containerHostname.isEmpty()
@@ -120,7 +120,7 @@ class DockerComposePluginTest extends Specification {
         project.plugins.apply 'docker-compose'
         def extension = (ComposeExtension) project.extensions.findByName('dockerCompose')
         project.tasks.create('integrationTest').doLast {
-            ServiceInstanceInfo webInfo = project.dockerCompose.servicesInfos.web.serviceInstanceInfos[0]
+            ServiceInstanceInfo webInfo = project.dockerCompose.servicesInfos.web.firstInstance
             assert webInfo.ports.containsKey(8080)
             assert webInfo.ports.containsKey(80)
         }
@@ -159,8 +159,8 @@ class DockerComposePluginTest extends Specification {
         def project = ProjectBuilder.builder().withProjectDir(projectDir).build()
         project.plugins.apply 'docker-compose'
         project.tasks.create('integrationTest').doLast {
-            assert project.dockerCompose.servicesInfos.web.serviceInstanceInfos[0].ports.containsKey(80)
-            assert project.dockerCompose.servicesInfos.devweb.serviceInstanceInfos[0].ports.containsKey(80)
+            assert project.dockerCompose.servicesInfos.web.firstInstance.ports.containsKey(80)
+            assert project.dockerCompose.servicesInfos.devweb.firstInstance.ports.containsKey(80)
         }
         when:
             project.tasks.composeUp.up()
@@ -200,7 +200,7 @@ class DockerComposePluginTest extends Specification {
         project.plugins.apply 'docker-compose'
         def extension = (ComposeExtension) project.extensions.findByName('dockerCompose')
         project.tasks.create('integrationTest').doLast {
-            ServiceInstanceInfo webInfo = project.dockerCompose.servicesInfos.web.serviceInstanceInfos[0]
+            ServiceInstanceInfo webInfo = project.dockerCompose.servicesInfos.web.firstInstance
             assert webInfo.ports.containsKey(8080)
             assert !webInfo.ports.containsKey(80)
             assert !project.dockerCompose.servicesInfos.devweb
@@ -306,7 +306,7 @@ class DockerComposePluginTest extends Specification {
         def project = ProjectBuilder.builder().withProjectDir(projectDir).build()
         project.plugins.apply 'docker-compose'
         project.tasks.composeUp.up()
-        String containerId = project.dockerCompose.servicesInfos.hello.serviceInstanceInfos[0].containerId
+        String containerId = project.dockerCompose.servicesInfos.hello.firstInstance.containerId
         when:
             String output = project.tasks.composeUp.getServiceLogs(containerId)
         then:
@@ -332,7 +332,7 @@ class DockerComposePluginTest extends Specification {
         project.plugins.apply 'docker-compose'
         def extension = (ComposeExtension) project.extensions.findByName('dockerCompose')
         project.tasks.create('integrationTest').doLast {
-            ServiceInstanceInfo webInfo = project.dockerCompose.servicesInfos.web.serviceInstanceInfos[0]
+            ServiceInstanceInfo webInfo = project.dockerCompose.servicesInfos.web.firstInstance
             assert webInfo.ports.containsKey(80)
         }
         when:
@@ -394,6 +394,8 @@ class DockerComposePluginTest extends Specification {
         project.tasks.create('integrationTest').doLast {
             def webInfos = project.dockerCompose.servicesInfos.web.serviceInstanceInfos
             assert webInfos.size() == 2
+            assert webInfos.containsKey('web_1')
+            assert webInfos.containsKey('web_2')
         }
         when:
             project.tasks.composeUp.up()


### PR DESCRIPTION
This implements issue #37 
Both `--scale` option as well as added parameter `scale:` in compose file version 2.2 are supported.

The scale does introduce a new concept where multiple instances of one service might exist and therefore naming exactly how compose names containers have to be used. That directly impacts both exposed environment variable and system property names and getting serviceInfos by name.
I would like to hear Your opinion on how to deal with this since at the current state this PR isn't backwards compatible with service naming used in mentioned functionality.