### PR TITLE
Moved --remove-orphans option from 'stop' to 'down' command

### DIFF
--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDown.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDown.groovy
@@ -22,9 +22,6 @@ class ComposeDown extends DefaultTask {
                 extension.setExecSpecWorkingDirectory(e)
                 e.environment = extension.environment
                 String[] args = ['stop', '--timeout', extension.dockerComposeStopTimeout.getSeconds()]
-                if (extension.removeOrphans()) {
-                    args += '--remove-orphans'
-                }
                 e.commandLine extension.composeCommand(args)
             }
             if (extension.removeContainers) {
@@ -40,6 +37,9 @@ class ComposeDown extends DefaultTask {
                     }
                     if(extension.removeVolumes) {
                         args += ['--volumes']
+                    }
+                    if (extension.removeOrphans()) {
+                        args += '--remove-orphans'
                     }
                     project.exec { ExecSpec e ->
                         extension.setExecSpecWorkingDirectory(e)


### PR DESCRIPTION
NOTES
=====

- Issue #72 added support for the `--remove-orphans` option to both _ComposeUp_ and _ComposeDown_ tasks. However, the implementation of the _ComposeDown_ task adds the said option in the buildup of the 'stop' command and not 'down' where the said option is supported.
