### PR TITLE
#85: Add fallback to instance name regex for custom container names

### DIFF
--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
@@ -121,7 +121,7 @@ class ComposeUp extends DefaultTask {
             ServiceHost host = getServiceHost(serviceName, inspection)
             logger.info("Will use $host as host of service $serviceName")
             def tcpPorts = getTcpPortsMapping(serviceName, inspection, host)
-            String instanceName = inspection.Name.find(/${serviceName}_\d+/)
+            String instanceName = inspection.Name.find(/${serviceName}_\d+/) ?: inspection.Name - '/'
             [(instanceName): new ContainerInfo(
                                 instanceName: instanceName,
                                 serviceHost: host,


### PR DESCRIPTION
This PR includes a fix for #85 by adding a fallback in the `instanceName` extraction regex in ComposeUp. This fallback will be used when a custom container name has been specified.

The fallback behaviour is to simply remove the leading slash from the container name.