### PR TITLE
#90 adding option to save container output to a logfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ dockerCompose.isRequiredBy(test) // hooks 'dependsOn composeUp' and 'finalizedBy
 
 dockerCompose {
     // useComposeFiles = ['docker-compose.yml', 'docker-compose.prod.yml'] // like 'docker-compose -f <file>'
-    // captureContainersOutput = true // prints output of all containers to Gradle output - very useful for debugging
+    // captureContainersOutput = true OR '/path/to/logFile' // sends output of all containers either to Gradle output (when set to true), or to a log file (when set to a String)
     // stopContainers = false // doesn't call `docker-compose down` - useful for debugging
     // removeContainers = false
     // removeImages = "None" // Other accepted values are: "All" and "Local"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ dockerCompose.isRequiredBy(test) // hooks 'dependsOn composeUp' and 'finalizedBy
 
 dockerCompose {
     // useComposeFiles = ['docker-compose.yml', 'docker-compose.prod.yml'] // like 'docker-compose -f <file>'
-    // captureContainersOutput = true OR '/path/to/logFile' // sends output of all containers either to Gradle output (when set to true), or to a log file (when set to a String)
+    // captureContainersOutput = true // prints output of all containers to Gradle output - very useful for debugging
+    // captureContainersOutputToFile = '/path/to/logFile' // sends output of all containers to a log file
     // stopContainers = false // doesn't call `docker-compose down` - useful for debugging
     // removeContainers = false
     // removeImages = "None" // Other accepted values are: "All" and "Local"

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
@@ -19,7 +19,7 @@ class ComposeExtension {
 
     boolean buildBeforeUp = true
     boolean waitForTcpPorts = true
-    boolean captureContainersOutput = false
+    Object captureContainersOutput = false
     Duration waitAfterTcpProbeFailure = Duration.ofSeconds(1)
     Duration waitForTcpPortsTimeout = Duration.ofMinutes(15)
     Duration waitForTcpPortsDisconnectionProbeTimeout = Duration.ofMillis(1000)

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
@@ -108,7 +108,7 @@ class ComposeExtension {
     }
 
     void setCaptureContainersOutputToFile(CharSequence path) {
-        captureContainersOutputToFile = new File(path)
+        captureContainersOutputToFile = project.file(path)
     }
 
     void setCaptureContainersOutputToFile(File file) {

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
@@ -19,7 +19,8 @@ class ComposeExtension {
 
     boolean buildBeforeUp = true
     boolean waitForTcpPorts = true
-    Object captureContainersOutput = false
+    boolean captureContainersOutput = false
+    File captureContainersOutputToFile = null
     Duration waitAfterTcpProbeFailure = Duration.ofSeconds(1)
     Duration waitForTcpPortsTimeout = Duration.ofMinutes(15)
     Duration waitForTcpPortsDisconnectionProbeTimeout = Duration.ofMillis(1000)
@@ -104,6 +105,14 @@ class ComposeExtension {
         if (dockerComposeWorkingDirectory != null) {
             e.setWorkingDir(dockerComposeWorkingDirectory)
         }
+    }
+
+    void setCaptureContainersOutputToFile(CharSequence path) {
+        captureContainersOutputToFile = new File(path)
+    }
+
+    void setCaptureContainersOutputToFile(File file) {
+        captureContainersOutputToFile = file
     }
 
     /**

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
@@ -55,9 +55,7 @@ class ComposeUp extends DefaultTask {
         }
         try {
             if (extension.captureContainersOutput) {
-                if (extension.captureContainersOutput) {
-                    captureContainersOutput(logger.&lifecycle)
-                }
+                captureContainersOutput(logger.&lifecycle)
             }
             if (extension.captureContainersOutputToFile != null) {
                 def logFile = extension.captureContainersOutputToFile

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
@@ -54,16 +54,15 @@ class ComposeUp extends DefaultTask {
             e.commandLine extension.composeCommand(args)
         }
         try {
-            if (extension.captureContainersOutput instanceof Boolean) {
+            if (extension.captureContainersOutput) {
                 if (extension.captureContainersOutput) {
                     captureContainersOutput(logger.&lifecycle)
                 }
-            } else if (extension.captureContainersOutput instanceof CharSequence) {
-                def logFile = new File(extension.captureContainersOutput)
+            }
+            if (extension.captureContainersOutputToFile != null) {
+                def logFile = extension.captureContainersOutputToFile
                 logFile.parentFile.mkdirs()
                 captureContainersOutput(logFile.&write)
-            } else {
-                throw new IllegalArgumentException("Illegal type of captureContainersOutput '${extension.captureContainersOutput.class.name}' expected boolean or CharSequence")
             }
             servicesInfos = loadServicesInfo().collectEntries { [(it.name): (it)] }
             waitForHealthyContainers(servicesInfos.values())

--- a/src/test/groovy/com/avast/gradle/dockercompose/DockerComposePluginTest.groovy
+++ b/src/test/groovy/com/avast/gradle/dockercompose/DockerComposePluginTest.groovy
@@ -5,7 +5,12 @@ import com.avast.gradle.dockercompose.tasks.ComposeUp
 import com.avast.gradle.dockercompose.tasks.ComposePull
 import org.gradle.api.Task
 import org.gradle.api.internal.file.TmpDirTemporaryFileProvider
+import org.gradle.api.logging.LogLevel
 import org.gradle.api.tasks.testing.Test
+import org.gradle.internal.logging.events.LogEvent
+import org.gradle.internal.logging.events.OutputEvent
+import org.gradle.internal.logging.events.OutputEventListener
+import org.gradle.internal.logging.slf4j.Slf4jLoggingConfigurer
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.IgnoreIf
 import spock.lang.Specification
@@ -96,6 +101,76 @@ class DockerComposePluginTest extends Specification {
         then:
             noExceptionThrown()
         cleanup:
+            try {
+                projectDir.delete()
+            } catch (ignored) {
+                projectDir.deleteOnExit()
+            }
+    }
+
+    def "captures container output to stdout"() {
+        def projectDir = new TmpDirTemporaryFileProvider().createTemporaryDirectory("gradle", "projectDir")
+        new File(projectDir, 'docker-compose.yml') << '''
+            web:
+                image: nginx
+                command: bash -c "echo 'heres some output' && sleep 5 && nginx -g 'daemon off;'"
+                ports:
+                  - 80
+        '''
+        def project = ProjectBuilder.builder().withProjectDir(projectDir).build()
+
+        project.plugins.apply 'docker-compose'
+        def extension = (ComposeExtension) project.extensions.findByName('dockerCompose')
+
+        def stdout = new StringBuffer()
+
+        new Slf4jLoggingConfigurer(new OutputEventListener() {
+            @Override
+            void onOutput(OutputEvent outputEvent) {
+                if (outputEvent instanceof LogEvent) {
+                    stdout.append(((LogEvent) outputEvent).message)
+                }
+            }
+        }).configure(LogLevel.LIFECYCLE)
+
+        when:
+            extension.captureContainersOutput = true
+            project.tasks.composeUp.up()
+        then:
+            noExceptionThrown()
+            stdout.toString().contains("heres some output")
+        cleanup:
+            project.tasks.composeDown.down()
+            try {
+                projectDir.delete()
+            } catch (ignored) {
+                projectDir.deleteOnExit()
+            }
+    }
+
+    def "captures container output to file"() {
+        def projectDir = new TmpDirTemporaryFileProvider().createTemporaryDirectory("gradle", "projectDir")
+        new File(projectDir, 'docker-compose.yml') << '''
+            web:
+                image: nginx
+                command: bash -c "echo 'heres some output' && sleep 5 && nginx -g 'daemon off;'"
+                ports:
+                  - 80
+        '''
+        def project = ProjectBuilder.builder().withProjectDir(projectDir).build()
+        def logFile = new File(projectDir, "web.log")
+
+        project.plugins.apply 'docker-compose'
+        def extension = (ComposeExtension) project.extensions.findByName('dockerCompose')
+
+        when:
+            extension.captureContainersOutput = "${logFile.absolutePath}"
+            project.tasks.composeUp.up()
+        then:
+            noExceptionThrown()
+            logFile.text.contains("heres some output")
+        cleanup:
+            project.tasks.composeDown.down()
             try {
                 projectDir.delete()
             } catch (ignored) {


### PR DESCRIPTION
I took a quick swing at adding the feature discussed in issue #90. Users can set `captureContainersOutput` to either `true` or a String to save output to.