### PR TITLE
Fix for #83

### DIFF
--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
@@ -5,6 +5,7 @@ import com.avast.gradle.dockercompose.tasks.ComposeUp
 import groovy.transform.PackageScope
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.process.ExecSpec
 import org.gradle.process.JavaForkOptions
 import org.gradle.process.ProcessForkOptions
@@ -48,6 +49,13 @@ class ComposeExtension {
         this.project = project
         this.downTask = downTask
         this.upTask = upTask
+
+        if (OperatingSystem.current().isMacOsX()) {
+            // Default installation is inaccessible from path, so set sensible
+            // defaults for this platform.
+            this.executable = '/usr/local/bin/docker-compose'
+            this.dockerExecutable = '/usr/local/bin/docker'
+        }
     }
 
     void isRequiredBy(Task task) {


### PR DESCRIPTION
https://github.com/avast/docker-compose-gradle-plugin/issues/83

The default docker installation instructions for macOS leave the docker tools accessible from `/usr/local/bin`. Unfortunately that's not on the default macOS path.

The simplest solution I could think of is to set the default for macOS to `/usr/local/bin/docker-compose` and `/usr/local/bin/docker`. This still allows plugin users to override these values in their own `build.gradle` files.