### PR TITLE
Implements docker-compose exec task

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Simplifies usage of [Docker Compose](https://www.docker.com/docker-compose) for 
 
 `composeLogs` task stores logs from all containers to files in `containerLogToDir` directory.
 
+`composeExec` task execute a command in a running container. Use `--service` argument to pass service name. 
+
 ## Quick start
 ```gradle
 buildscript {
@@ -119,6 +121,8 @@ dockerCompose {
     dockerComposeWorkingDirectory = project.file('/path/where/docker-compose/is/invoked/from')
     dockerComposeStopTimeout = java.time.Duration.ofSeconds(20) // time before docker-compose sends SIGTERM to the running containers after the composeDown task has been started
     environment.put 'BACKEND_ADDRESS', '192.168.1.100' // environment variables to be used when calling 'docker-compose', e.g. for substitution in compose file
+    
+    noTty = false // disable pseudo-TTY allocation. By default docker compose exec allocates a TTY.
 }
 
 test.doFirst {

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
@@ -3,6 +3,7 @@ package com.avast.gradle.dockercompose
 import com.avast.gradle.dockercompose.tasks.ComposeBuild
 import com.avast.gradle.dockercompose.tasks.ComposeDown
 import com.avast.gradle.dockercompose.tasks.ComposeDownForced
+import com.avast.gradle.dockercompose.tasks.ComposeExec
 import com.avast.gradle.dockercompose.tasks.ComposeLogs
 import com.avast.gradle.dockercompose.tasks.ComposePull
 import com.avast.gradle.dockercompose.tasks.ComposePush
@@ -37,6 +38,7 @@ abstract class ComposeSettings {
     final TaskProvider<ComposePull> pullTask
     final TaskProvider<ComposeLogs> logsTask
     final TaskProvider<ComposePush> pushTask
+    final TaskProvider<ComposeExec> execTask
     final Project project
     final DockerExecutor dockerExecutor
     final ComposeExecutor composeExecutor
@@ -84,6 +86,7 @@ abstract class ComposeSettings {
     abstract DirectoryProperty getCaptureContainersOutputToFiles()
     abstract RegularFileProperty getComposeLogToFile()
     abstract DirectoryProperty getContainerLogToDir()
+    abstract Property<Boolean> getNoTty()
 
     protected String customProjectName
     protected Boolean customProjectNameSet
@@ -158,6 +161,7 @@ abstract class ComposeSettings {
         checkContainersRunning.set(true)
 
         captureContainersOutput.set(false)
+        noTty.set(false)
 
         if (OperatingSystem.current().isMacOsX()) {
             // Default installation is inaccessible from path, so set sensible
@@ -180,6 +184,7 @@ abstract class ComposeSettings {
         downForcedTask = project.tasks.register(name ? "${name}ComposeDownForced".toString() : 'composeDownForced', ComposeDownForced, { it.settings = this })
         logsTask = project.tasks.register(name ? "${name}ComposeLogs".toString() : 'composeLogs', ComposeLogs, { it.settings = this })
         pushTask = project.tasks.register(name ? "${name}ComposePush".toString() : 'composePush', ComposePush, { it.settings = this })
+        execTask = project.tasks.register(name ? "${name}ComposeExec".toString() : 'composeExec', ComposeExec, { it.settings = this })
 
         this.dockerExecutor = project.objects.newInstance(DockerExecutor, this)
         this.composeExecutor = project.objects.newInstance(ComposeExecutor, this)
@@ -237,6 +242,7 @@ abstract class ComposeSettings {
 
         r.dockerComposeWorkingDirectory.set(this.dockerComposeWorkingDirectory.getOrNull())
         r.dockerComposeStopTimeout.set(this.dockerComposeStopTimeout.get())
+        r.noTty.set(this.noTty.get())
         r
     }
 

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeExec.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeExec.groovy
@@ -1,0 +1,37 @@
+package com.avast.gradle.dockercompose.tasks
+
+import com.avast.gradle.dockercompose.ComposeSettings
+import groovy.transform.CompileStatic
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
+
+@CompileStatic
+class ComposeExec extends DefaultTask {
+
+    @Internal
+    ComposeSettings settings
+
+    private String service
+
+    ComposeExec() {
+        group = 'docker'
+        description = 'Execute a command in a running container.'
+    }
+
+    @TaskAction
+    void push() {
+        String[] args = ['exec']
+        if (settings.noTty.get()) {
+            args += '--no-TTY'
+        }
+        args+=service
+        settings.composeExecutor.execute(args)
+    }
+
+    @Option(option = "service", description = "Service name to execute command.")
+    void setService(String service) {
+        this.service = service
+    }
+}


### PR DESCRIPTION
Hi

For the very beginning many thanks for great plugin! It helps us a lot to setup our integration tests rocks!
Some time ago we started to automate build&test process of out php based apps and we need to execute composer commands during this process. Using your plugin I setup some custom tasks which do the job:

```groovy
plugins {
 id 'com.avast.gradle.docker-compose' version "0.14.9"
}

tasks.register('composerInstall') {
    dependsOn tasks.composeUp
    doLast {
        String[] composerInstallCmd = ['exec', '-T', 'php', 'composer', 'install']
            dockerCompose.composeExecutor.execute(composerInstallCmd)
    }
}

tasks.register('composerTest') {
    dependsOn tasks.composerInstall
    doLast {
        String[] composerTestCmd = ['exec', '-T', 'php', 'composer', 'test']
            dockerCompose.composeExecutor.execute(composerTestCmd)
    }
}

dockerCompose.isRequiredBy(composerInstall)
dockerCompose.isRequiredBy(composerTest)
```

but I think it could be useful to add another specific task for `docker-compose exec`, what do you think?